### PR TITLE
Lucibranch

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -68,7 +68,7 @@ Note: the use of the word "segmentation" in this case is coincidence. A segmenta
 If you were using an aseg supplied from an external source (other than PreFreeSurfer) the file might have an orientation or dimension or other property that is not what FreeSurfer expected. Or, if you were using a mask from another source, the aseg file and the mask file might not have the same dimensions. Or it could just be that the aseg was not very good.
 
 
-### Troubleshooting Task Errors in Pipeline Logs
+### Troubleshooting Functional Errors in Pipeline Logs
 
 These pipeline stages process task data: FMRIVolume, FMRISurface, DCANBOLDProcessing. When you go to any of those subdirectories in the processed data logs, you will find multiple output and error files: one for each task/run combination that was processed when the pipeline failed, and, in some cases, files for setup and teardown steps.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -43,7 +43,80 @@ Look higher in the output log to find the last stage that was started. Copy the 
 
 If the job failed but did not time out, the Slurm error log will usually have a line that says `Exception: error caught during stage:` followed by the name of the stage. Note the stage name. That's the stage to start from when you resubmit, _after _you figure out why it failed and fix the problem. This usually requires looking at the pipeline logs. To find them, look at the bottom of the Slurm output log for the string `COPY PROCESSED DATA TO` to find the path to the data for that study. Go to that path and then into the tree for `&lt;subject>/&lt;session>/logs/&lt;stage>`.
 
-When using pipeline logs, remember: cascading errors are of no use to you; you only care about the _first _error that happened in the stage. 
+When using pipeline logs, remember: cascading errors are of no use to you; you only care about the _first _error that happened in the stage. See following sections for how to troubleshoot errors in various stages of the pipeline with the pipeline logs.
+
+### Troubleshooting Anatomical Errors in Pipeline Logs
+
+The stages that constitute anatomical processing are PreFreeSurfer, FreeSurfer, and PostFreeSurfer. The following are common errors we see when processing infant data with the DCAN pipeline:
+
+
+#### No aseg_acpc.nii.gz File
+
+The first stage of the pipeline is PreFreeSurfer. The most crucial file that should come from this stage is its segmentation, aka aseg (`files/T1w/aseg_acpc.nii.gz`).
+
+If PreFreeSurfer failed to make the aseg, look in the PreFreeSurfer error file for the first error. If the error occurred in JLF, resubmit your job. JLF fails intermittently and the job may succeed next time.
+
+If the first error was before JLF, or if you run this multiple times and JLF fails each time, refer to the section on [inspecting the intermediate pipeline output files](https://github.com/DCAN-Labs/data-processing-handbook/edit/lucibranch/docs/troubleshooting.md#inspecting-the-data-for-quality-or-processing-issues) to troubleshoot.
+
+
+#### FreeSurfer failed in mri_normalize
+
+In both of FreeSurfer's logs you will find the string `ERROR: After mri_normalize, &lt;subject id>/mri/T1.mgz does not exist.` In the error file, you will also find the string `Segmentation fault`. This usually occurs when FreeSurfer doesn't like the aseg file.
+
+Note: the use of the word "segmentation" in this case is coincidence. A segmentation fault is a runtime error in the code, for example, trying to divide by 0 will throw a segmentation fault. It just so happens that the segmentation fault can happen in mri_normalize when there is a problem with the aseg file. But it can also happen if there is a problem with the mask. So do not assume that a segmentation fault always refers to the segmentation file. This is one reason I often refer to the segmentation file as the aseg.
+
+If you were using an aseg supplied from an external source (other than PreFreeSurfer) the file might have an orientation or dimension or other property that is not what FreeSurfer expected. Or, if you were using a mask from another source, the aseg file and the mask file might not have the same dimensions. Or it could just be that the aseg was not very good.
+
+
+### Troubleshooting Task Errors in Pipeline Logs
+
+These pipeline stages process task data: FMRIVolume, FMRISurface, DCANBOLDProcessing. When you go to any of those subdirectories in the processed data logs, you will find multiple output and error files: one for each task/run combination that was processed when the pipeline failed, and, in some cases, files for setup and teardown steps.
+
+The runs are processed in parallel, and the pipeline does not fail until all of the steps of the stage have either passed or failed, so you cannot assume the last run is "guilty". Also, more than one run might have a problem. The quickest way to check what failed is to look at the file called `status.json`. You will see something like `stage terminated with exit code [0, 0, 1, 1]`. In this example, 2 steps failed, and they were the 3rd and 4th steps. If the stage has a setup and teardown (like DCANBOLDProcessing), then this status would tell you that setup and the first run succeeded, the second run failed, and teardown failed. If this `status.json` were found in FMRIVolume, then the 3rd and 4th runs failed (because there is no setup or teardown in FMRIVolume). Just look around at the output and error files available in the directory and it should make sense.
+
+Another way to check which step failed is: type `tail *.err` which will show the last 10 lines of each error file. Each run that succeeded will end with a message to indicate that the stage completed. For example, each successful run in FMRIVolume would have the message, `GenericfMRIVolumeProcessingPipeline.sh - Completed` at the end. Any file that does not have such a message has had an error. Open the file and look for the first error.
+
+
+#### FMRIVolume Could Not Create a Scout File
+
+The most common error in FMRIVolume occurs when a Scout file cannot be created. In the current version, you will find `Too few frames...Exiting`.
+
+We try to use the 17th frame in the file to make the Scout file because the babies have settled a little bit by then. We can use a different frame, but, if there are &lt; 17 frames, the data is not much use. The fix is to remove that file from your `func `directory so that the pipeline will not try to process it. You can restart at FMRIVolume, since no `func `files will have been used before this stage.
+
+#### FMRISurface Did Not Find All ROIs
+
+During FMRISurface we attempt to map the subcortical areas. If you ran using ROI_MAP as your subcortical-map-method (the default), the pipeline split the subcorticals and attempted to map each. The pipeline expected to find 19 regions of interest (ROIs). Sometimes an aseg will not have all 19 ROIs. The error log for the run will have the string `ERROR: cifti xml dimensions must be greater than zero`. 
+
+Which subcortical was missing may not matter to you. The message means the run cannot be used as is, so you can decide to eliminate that run. But if you want to debug further, look at the line above that message. It will say something like:
+
+
+```
+    wb_command -cifti-create-dense-timeseries /output/.../files/MNINonLinear/ROIs/task-rest_run-01_working_directory/task-rest_run-01_temp_subject_ROI0008.dtseries.nii -volume sub2atl_vol_masked_ROI0008.nii.gz /output/.../files/MNINonLinear/ROIs/task-rest_run-01_working_directory/sub2atl_vol_label_ROI0008.nii.gz
+```
+
+
+From the message you can find:
+
+
+
+* The working directory. Since the job was probably run using Docker, the path to the working directory cannot be used “as is”. Your data will have been mounted to `/output`, so you would substitute the appropriate path for `/output`. Hint: the working directory will always be `files/MNINonLinear/ROIs/&lt;frminame>`. 
+* The first ROI for which no data was found. In our example, ROI0008. Since the ROI files are made using `wb_command -volume-all-labels-to-rois`, the ROI numbering starts at 0. That is, ROI0000 is the name used for the 1st ROI. So ROI0008 represents the 9th ROI. 
+
+Go to the working directory (it will not have been removed since there were errors), andl find a file named `labelfile.txt`. The file has 2 lines per ROI, so, for the 9th ROI, you want to look at lines 17 and 18:
+
+
+```
+    17: ACCUMBENS_LEFT
+    18: 26 255 165 0 255
+```
+
+
+
+The first missing ROI was the left accumbens. Its FreeSurfer label was 26 (that is, if you viewed the file with fslview, its “intensity” would be 26). If you have a way to correct the aseg, that is the ROI you need to add.
+
+There might be more missing ROIs; the command died at the first one.
+
+
 
 
 ### Inspecting the data for quality or processing issues

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,7 +6,41 @@ For any processing failures, we triage what happened. Most troubleshooting proce
 Image viewing is a necessary process to conclude if a pipeline job finished successfully, but it also may be necessary when a processing error has been encountered. There are a few different options for viewing anatomical images. It may be most efficient to first download the images locally and then use ITKsnap to view them. However, when working on MSI, applications such as `fslview_deprecated` or `fsleyes` can be used. For viewing functional images, `wb_view` is ideal (make sure to `module load fsl` or `module load workbench` before using these applications). For more information on nifti and cifti files (image file types), refer to the video sessions in the subfolders of [this google drive folder](https://drive.google.com/drive/u/0/folders/1yc3w2zNYVZQvTcCgxKk_j6ecZLoyWiCM).
 
 
-## infant-abcd-bids-pipeline (DCAN Infant Pipeline)
+## DCAN Infant Pipeline (infant-abcd-bids-pipeline)
+
+### Common errors
+
+The Slurm logs will tell you which stage of the pipeline failed. The Slurm Readout prior to exiting will look something like this:
+
+```
+	_cli()
+  File "/app/run.py", line 80, in _cli
+	return interface(**kwargs)
+  File "/app/run.py", line 585, in interface
+	stage.run(ncpus)
+  File "/app/pipelines.py", line 697, in run
+	self.teardown(result)
+  File "/app/pipelines.py", line 637, in teardown
+	self.__class__.__name__)
+Exception: error caught during stage: FMRISurface
+
+File "/app/run.py", line 589, in <module>
+	_cli()
+  File "/app/run.py", line 80, in _cli
+	return interface(**kwargs)
+  File "/app/run.py", line 585, in interface
+	stage.run(ncpus)
+  File "/app/pipelines.py", line 697, in run
+	self.teardown(result)
+  File "/app/pipelines.py", line 637, in teardown
+	self.__class__.__name__)
+Exception: error caught during stage: FreeSurfer stage
+```
+
+In order to assess the errors more closely, go to the logs that are output from each stage of the pipeline.
+
+
+### Inspecting the data for quality or processing issues
 
 1. First follow established SOPs to check that the input data is high quality enough to be processed: see *Structural Pre-Processing Quality Assessment of BIDS* under [Quality Control for Infant Data](https://dcanlab.readthedocs.io/en/latest/manualpro/infant/qc/) on the DCAN Labs RTDs 
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,7 +8,7 @@ Image viewing is a necessary process to conclude if a pipeline job finished succ
 
 ## DCAN Infant Pipeline (infant-abcd-bids-pipeline)
 
-### Common errors
+### Common errors when processing with the DCAN infant pipeline
 
 The Slurm logs will tell you which stage of the pipeline failed. The Slurm Readout prior to exiting will look something like this:
 


### PR DESCRIPTION
pulled info from DCAN RTD section: [Common Infant Pipeline Errors and How to Fix Them](https://dcanlab.readthedocs.io/en/stable/manualpro/infant/error/) and added to troubleshoot.md.  Structure now looks like this:

**Troubleshooting and Image Viewing**
*DCAN Infant Pipeline (infant-abcd-bids-pipeline)*
Inspecting slurm and pipeline logs for errors
Troubleshooting Anatomical Errors in Pipeline Logs
Troubleshooting Functional Errors in Pipeline Logs
Inspecting the data for quality or processing issues

